### PR TITLE
Add missing custom color enrtries in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,10 +15,14 @@ theme:
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
+      primary: custom
+      accent: custom
     - scheme: slate
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode
+      primary: custom
+      accent: custom
 markdown_extensions:
   - attr_list
   - admonition

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+mkdocs
 mkdocs-material
 lightgallery
+


### PR DESCRIPTION
mkdocs-material requires `primary` and `accent` set to custom to work with custom css properly. In newer versions, this seems to be a strict requirement. We got away without it in older versions, but the site colors are wrong without it in newer versions.

Simple fix and correct according to mkdocs-material docs.