### PR TITLE
Add Actions workflow for deploying site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+# Based on https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions-material-for-mkdocs
+name: Deploy Site
+on: workflow_dispatch
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install -r requirements.txt -U
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Creates Github Actions workflow called "Deploy Site". This is manually triggered workflow. It will run `mkdocs gh-deploy` in a consistent environment.

Note that mkdocs has it's own workflow once things are actually pushed. So running the manually triggered workflow will invoke `mkdocs gh-deploy` which then pushes to the `gh-pages` branch which triggers the internal mkdocs workflow to actually deploy.